### PR TITLE
frontend: update accounts list after keystore rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,9 @@ Place Go tests in `_test.go` files and run `go test -mod=vendor ./...` (optional
 `scripts/coverage.sh` to emit `coverage.cov`). Frontend unit specs live beside components as
 `*.test.ts(x)`; invoke `make webtest` for the suite. Use `make webe2etest` for Playwright smoke
 flows and document new scenarios in `frontends/web/tests/README.md` if they require fixtures.
+- If you change an interface that has a `//go:generate` directive in its docstring, run the
+  corresponding `go generate` command for that file before finishing the change. For example, if
+  you change the `Keystore` interface, regenerate the keystore mocks.
 
 ### Frontend Test Patterns
 See `src/components/forms/button.test.tsx` for component test examples and `src/hooks/api.test.ts`

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -836,6 +836,23 @@ func (backend *Backend) RenameAccount(accountCode accountsTypes.Code, name strin
 	return nil
 }
 
+// updateKeystoreName persists a keystore name change and re-sorts the loaded accounts accordingly.
+func (backend *Backend) updateKeystoreName(rootFingerprint []byte, name string) error {
+	if name == "" {
+		return errp.New("Name cannot be empty")
+	}
+	if err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
+		accountsConfig.GetOrAddKeystore(rootFingerprint).Name = name
+		return nil
+	}); err != nil {
+		return err
+	}
+	defer backend.accountsAndKeystoreLock.Lock()()
+	sortAccounts(backend.accounts, backend.config.AccountsConfig())
+	backend.emitAccountsStatusChanged()
+	return nil
+}
+
 // addAccount adds the given account to the backend.
 // The accountsAndKeystoreLock must be held when calling this function.
 func (backend *Backend) addAccount(account accounts.Interface) {

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -131,6 +131,11 @@ func TestAccounts(t *testing.T) {
 }
 
 func TestSortAccounts(t *testing.T) {
+	const (
+		alphaWalletName = "Alpha"
+		betaWalletName  = "Beta"
+	)
+
 	xpub, err := hdkeychain.NewMaster(make([]byte, 32), &chaincfg.TestNet3Params)
 	require.NoError(t, err)
 	xpub, err = xpub.Neuter()
@@ -169,11 +174,11 @@ func TestSortAccounts(t *testing.T) {
 	backend := newBackend(t, testnetDisabled, regtestDisabled)
 	require.NoError(t, backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		keystore1 := accountsConfig.GetOrAddKeystore(rootFingerprint1)
-		keystore1.Name = "Beta"
+		keystore1.Name = betaWalletName
 		keystore2 := accountsConfig.GetOrAddKeystore(rootFingerprint2)
-		keystore2.Name = "Alpha"
+		keystore2.Name = alphaWalletName
 		keystore3 := accountsConfig.GetOrAddKeystore(rootFingerprint3)
-		keystore3.Name = "Beta"
+		keystore3.Name = betaWalletName
 		return nil
 	}))
 	unlockFN := backend.accountsAndKeystoreLock.Lock()

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -268,16 +268,16 @@ func TestObserveKeystoreNameChanged(t *testing.T) {
 				keystoreObserver = nil
 			}
 		},
-		RootFingerprintFunc: func() ([]byte, error) {
-			return rootFingerprint1, nil
-		},
 	})
 	require.NotNil(t, keystoreObserver)
 
 	keystoreObserver(observable.Event{
 		Subject: string(keystorepkg.EventNameChanged),
 		Action:  action.Replace,
-		Object:  "Aardvark",
+		Object: keystorepkg.NameChangedEvent{
+			Name:            "Aardvark",
+			RootFingerprint: rootFingerprint1,
+		},
 	})
 
 	keystoreConfig, err := backend.Config().AccountsConfig().LookupKeystore(rootFingerprint1)

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -19,11 +19,14 @@ import (
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
+	keystorepkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	keystoremock "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/software"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -203,6 +206,89 @@ func TestSortAccounts(t *testing.T) {
 	for i, acct := range backend.Accounts() {
 		assert.Equal(t, expectedOrder[i], acct.Config().Config.Code)
 	}
+}
+
+func TestObserveKeystoreNameChanged(t *testing.T) {
+	xpub, err := hdkeychain.NewMaster(make([]byte, 32), &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+	xpub, err = xpub.Neuter()
+	require.NoError(t, err)
+
+	btcConfig := func(rootFingerprint []byte, keypath string) signing.Configurations {
+		kp, err := signing.NewAbsoluteKeypath(keypath)
+		require.NoError(t, err)
+		return signing.Configurations{
+			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, rootFingerprint, kp, xpub),
+		}
+	}
+
+	accountConfigs := []*config.Account{
+		{
+			Code:                  "acct-beta",
+			CoinCode:              coinpkg.CodeBTC,
+			SigningConfigurations: btcConfig(rootFingerprint1, "m/84'/0'/0'"),
+		},
+		{
+			Code:                  "acct-alpha",
+			CoinCode:              coinpkg.CodeBTC,
+			SigningConfigurations: btcConfig(rootFingerprint2, "m/84'/0'/0'"),
+		},
+	}
+
+	backend := newBackend(t, testnetDisabled, regtestDisabled)
+	defer backend.Close()
+	require.NoError(t, backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
+		accountsConfig.GetOrAddKeystore(rootFingerprint1).Name = "Beta"
+		accountsConfig.GetOrAddKeystore(rootFingerprint2).Name = "Alpha"
+		return nil
+	}))
+
+	unlockFN := backend.accountsAndKeystoreLock.Lock()
+	for i := range accountConfigs {
+		c, err := backend.Coin(accountConfigs[i].CoinCode)
+		require.NoError(t, err)
+		backend.createAndAddAccount(c, accountConfigs[i])
+	}
+	unlockFN()
+
+	require.Equal(t, accountsTypes.Code("acct-alpha"), backend.Accounts()[0].Config().Config.Code)
+	require.Equal(t, accountsTypes.Code("acct-beta"), backend.Accounts()[1].Config().Config.Code)
+
+	var events []observable.Event
+	unobserve := backend.Observe(func(event observable.Event) {
+		events = append(events, event)
+	})
+	defer unobserve()
+
+	var keystoreObserver func(observable.Event)
+	backend.observeKeystore(&keystoremock.KeystoreMock{
+		ObserveFunc: func(fn func(observable.Event)) func() {
+			keystoreObserver = fn
+			return func() {
+				keystoreObserver = nil
+			}
+		},
+		RootFingerprintFunc: func() ([]byte, error) {
+			return rootFingerprint1, nil
+		},
+	})
+	require.NotNil(t, keystoreObserver)
+
+	keystoreObserver(observable.Event{
+		Subject: string(keystorepkg.EventNameChanged),
+		Action:  action.Replace,
+		Object:  "Aardvark",
+	})
+
+	keystoreConfig, err := backend.Config().AccountsConfig().LookupKeystore(rootFingerprint1)
+	require.NoError(t, err)
+	require.Equal(t, "Aardvark", keystoreConfig.Name)
+	require.Equal(t, accountsTypes.Code("acct-beta"), backend.Accounts()[0].Config().Config.Code)
+	require.Equal(t, accountsTypes.Code("acct-alpha"), backend.Accounts()[1].Config().Config.Code)
+	require.Contains(t, events, observable.Event{
+		Subject: "accounts",
+		Action:  action.Reload,
+	})
 }
 
 func TestNextAccountNumber(t *testing.T) {
@@ -876,6 +962,9 @@ func TestTaprootUpgrade(t *testing.T) {
 	fingerprint := []byte{0x55, 0x055, 0x55, 0x55}
 
 	bitbox02NoTaproot := &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock no taproot", nil
 		},
@@ -902,6 +991,9 @@ func TestTaprootUpgrade(t *testing.T) {
 		BTCXPubsFunc:          keystoreHelper.BTCXPubs,
 	}
 	bitbox02Taproot := &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock taproot", nil
 		},
@@ -1169,6 +1261,9 @@ func TestWatchonly(t *testing.T) {
 		// A keystore with a similar config to a BitBox02 - supporting unified accounts, no legacy
 		// P2PKH.
 		ks1 := &keystoremock.KeystoreMock{
+			ObserveFunc: func(func(observable.Event)) func() {
+				return func() {}
+			},
 			NameFunc: func() (string, error) {
 				return "Mock keystore 1", nil
 			},
@@ -1191,6 +1286,9 @@ func TestWatchonly(t *testing.T) {
 			BTCXPubsFunc:          keystoreHelper1.BTCXPubs,
 		}
 		ks2 := &keystoremock.KeystoreMock{
+			ObserveFunc: func(func(observable.Event)) func() {
+				return func() {}
+			},
 			NameFunc: func() (string, error) {
 				return "Mock keystore 2", nil
 			},

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/software"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +46,9 @@ func makeKeystore(
 	t.Helper()
 
 	return &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock keystore", nil
 		},

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -218,6 +218,8 @@ type Backend struct {
 	accounts                AccountsList
 	// keystore is nil if no keystore is connected.
 	keystore keystore.Keystore
+	// Called to remove the current keystore observer, if any.
+	unobserveKeystore func()
 
 	connectKeystore connectKeystore
 
@@ -726,17 +728,18 @@ func (backend *Backend) Keystore() keystore.Keystore {
 
 // registerKeystore registers the given keystore at this backend.
 // if another keystore is already registered, it will be replaced.
-func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
+func (backend *Backend) registerKeystore(ks keystore.Keystore) {
 	defer backend.accountsAndKeystoreLock.Lock()()
 	// Only for logging, if there is an error we continue anyway.
-	fingerprint, err := keystore.RootFingerprint()
+	fingerprint, err := ks.RootFingerprint()
 	if err != nil {
 		backend.log.WithError(err).Error("could not retrieve keystore fingerprint")
 		return
 	}
 	log := backend.log.WithField("rootFingerprint", hex.EncodeToString(fingerprint))
 	log.Info("registering keystore")
-	backend.keystore = keystore
+	backend.observeKeystore(ks)
+	backend.keystore = ks
 	backend.Notify(observable.Event{
 		Subject: "keystores",
 		Action:  action.Reload,
@@ -747,7 +750,7 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	}
 
 	persistKeystore := func(accountsConfig *config.AccountsConfig) error {
-		keystoreName, err := keystore.Name()
+		keystoreName, err := ks.Name()
 		if err != nil {
 			return errp.WithMessage(err, "could not retrieve keystore name")
 		}
@@ -767,9 +770,9 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 		// needed on the persisted accounts.
 		accounts := backend.filterAccounts(accountsConfig, belongsToKeystore)
 		if len(accounts) != 0 {
-			return backend.updatePersistedAccounts(keystore, accounts)
+			return backend.updatePersistedAccounts(ks, accounts)
 		}
-		return backend.persistDefaultAccountConfigs(keystore, accountsConfig)
+		return backend.persistDefaultAccountConfigs(ks, accountsConfig)
 	})
 	if err != nil {
 		log.WithError(err).Error("Could not persist default accounts")
@@ -784,6 +787,31 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	go backend.maybeAddHiddenUnusedAccounts()
 }
 
+func (backend *Backend) observeKeystore(ks keystore.Keystore) {
+	if backend.unobserveKeystore != nil {
+		backend.unobserveKeystore()
+		backend.unobserveKeystore = nil
+	}
+	backend.unobserveKeystore = ks.Observe(func(event observable.Event) {
+		if event.Subject != string(keystore.EventNameChanged) {
+			return
+		}
+		name, ok := event.Object.(string)
+		if !ok {
+			backend.log.WithField("subject", event.Subject).Warn("keystore name change event without name")
+			return
+		}
+		rootFingerprint, err := ks.RootFingerprint()
+		if err != nil {
+			backend.log.WithError(err).Error("could not retrieve keystore fingerprint after name change")
+			return
+		}
+		if err := backend.updateKeystoreName(rootFingerprint, name); err != nil {
+			backend.log.WithError(err).Error("could not persist keystore name after name change")
+		}
+	})
+}
+
 // DeregisterKeystore removes the registered keystore.
 func (backend *Backend) DeregisterKeystore() {
 	defer backend.accountsAndKeystoreLock.Lock()()
@@ -795,6 +823,10 @@ func (backend *Backend) DeregisterKeystore() {
 	// Only for logging, if there is an error we continue anyway.
 	fingerprint, _ := backend.keystore.RootFingerprint()
 	backend.log.WithField("rootFingerprint", hex.EncodeToString(fingerprint)).Info("deregistering keystore")
+	if backend.unobserveKeystore != nil {
+		backend.unobserveKeystore()
+		backend.unobserveKeystore = nil
+	}
 	backend.keystore = nil
 	backend.Notify(observable.Event{
 		Subject: "keystores",
@@ -953,6 +985,10 @@ func (backend *Backend) Close() error {
 	errors := []string{}
 
 	backend.uninitAccounts(true)
+	if backend.unobserveKeystore != nil {
+		backend.unobserveKeystore()
+		backend.unobserveKeystore = nil
+	}
 
 	for _, coin := range backend.coins {
 		if err := coin.Close(); err != nil {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -796,17 +796,12 @@ func (backend *Backend) observeKeystore(ks keystore.Keystore) {
 		if event.Subject != string(keystore.EventNameChanged) {
 			return
 		}
-		name, ok := event.Object.(string)
+		nameChanged, ok := event.Object.(keystore.NameChangedEvent)
 		if !ok {
-			backend.log.WithField("subject", event.Subject).Warn("keystore name change event without name")
+			backend.log.WithField("subject", event.Subject).Warn("keystore name change event without payload")
 			return
 		}
-		rootFingerprint, err := ks.RootFingerprint()
-		if err != nil {
-			backend.log.WithError(err).Error("could not retrieve keystore fingerprint after name change")
-			return
-		}
-		if err := backend.updateKeystoreName(rootFingerprint, name); err != nil {
+		if err := backend.updateKeystoreName(nameChanged.RootFingerprint, nameChanged.Name); err != nil {
 			backend.log.WithError(err).Error("could not persist keystore name after name change")
 		}
 	})

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -69,6 +69,9 @@ var rootFingerprint2 = []byte{0x66, 0x66, 0x66, 0x66}
 func makeBitBox02Multi() *keystoremock.KeystoreMock {
 	ksHelper := keystoreHelper1()
 	return &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock name", nil
 		},
@@ -332,6 +335,9 @@ func TestRegisterKeystore(t *testing.T) {
 	// A keystore with a similar config to a BitBox02 - supporting unified accounts, no legacy
 	// P2PKH.
 	ks1 := &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock keystore 1", nil
 		},
@@ -354,6 +360,9 @@ func TestRegisterKeystore(t *testing.T) {
 		BTCXPubsFunc:          keystoreHelper1.BTCXPubs,
 	}
 	ks2 := &keystoremock.KeystoreMock{
+		ObserveFunc: func(func(observable.Event)) func() {
+			return func() {}
+		},
 		NameFunc: func() (string, error) {
 			return "Mock keystore 2", nil
 		},

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -153,11 +153,11 @@ func (device *Device) SetOnEvent(onEvent func(deviceevent.Event, interface{})) {
 
 // SetDeviceName updates the device name and notifies keystore observers.
 func (device *Device) SetDeviceName(deviceName string) error {
-	if err := device.Device.SetDeviceName(deviceName); err != nil {
-		return err
-	}
 	rootFingerprint, err := device.keystore.RootFingerprint()
 	if err != nil {
+		return err
+	}
+	if err := device.Device.SetDeviceName(deviceName); err != nil {
 		return err
 	}
 	device.keystore.Notify(observable.Event{

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -33,6 +33,7 @@ type Device struct {
 	deviceID    string
 	productName string
 	log         *logrus.Entry
+	keystore    *keystore
 
 	observable.Implementation
 }
@@ -72,6 +73,10 @@ func NewDevice(
 		productName: productName,
 		log:         log,
 	}
+	device.keystore = &keystore{
+		device: device,
+		log:    device.log,
+	}
 	device.Device.SetOnEvent(func(ev firmware.Event, meta interface{}) {
 		switch ev {
 		case firmware.EventStatusChanged:
@@ -91,6 +96,7 @@ func NewDevice(
 		case firmware.EventStatusChanged:
 			switch device.Device.Status() {
 			case firmware.StatusInitialized:
+				device.keystore.clearRootFingerprintCache()
 				device.Notify(observable.Event{
 					Subject: string(deviceevent.EventKeystoreAvailable),
 					Action:  action.Replace,
@@ -136,14 +142,24 @@ func (device *Device) Keystore() keystoreInterface.Keystore {
 	if device.Status() != firmware.StatusInitialized {
 		return nil
 	}
-	return &keystore{
-		device: device,
-		log:    device.log,
-	}
+	return device.keystore
 }
 
 // SetOnEvent implements device.Device.
 func (device *Device) SetOnEvent(onEvent func(deviceevent.Event, interface{})) {
+}
+
+// SetDeviceName updates the device name and notifies keystore observers.
+func (device *Device) SetDeviceName(deviceName string) error {
+	if err := device.Device.SetDeviceName(deviceName); err != nil {
+		return err
+	}
+	device.keystore.Notify(observable.Event{
+		Subject: string(keystoreInterface.EventNameChanged),
+		Action:  action.Replace,
+		Object:  deviceName,
+	})
+	return nil
 }
 
 // Reset factory resets the device.

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -5,6 +5,8 @@
 package bitbox02
 
 import (
+	"slices"
+
 	deviceevent "github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/device/event"
 	keystoreInterface "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
@@ -154,10 +156,17 @@ func (device *Device) SetDeviceName(deviceName string) error {
 	if err := device.Device.SetDeviceName(deviceName); err != nil {
 		return err
 	}
+	rootFingerprint, err := device.keystore.RootFingerprint()
+	if err != nil {
+		return err
+	}
 	device.keystore.Notify(observable.Event{
 		Subject: string(keystoreInterface.EventNameChanged),
 		Action:  action.Replace,
-		Object:  deviceName,
+		Object: keystoreInterface.NameChangedEvent{
+			Name:            deviceName,
+			RootFingerprint: slices.Clone(rootFingerprint),
+		},
 	})
 	return nil
 }

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -153,21 +153,28 @@ func (device *Device) SetOnEvent(onEvent func(deviceevent.Event, interface{})) {
 
 // SetDeviceName updates the device name and notifies keystore observers.
 func (device *Device) SetDeviceName(deviceName string) error {
-	rootFingerprint, err := device.keystore.RootFingerprint()
-	if err != nil {
-		return err
-	}
 	if err := device.Device.SetDeviceName(deviceName); err != nil {
 		return err
 	}
-	device.keystore.Notify(observable.Event{
-		Subject: string(keystoreInterface.EventNameChanged),
-		Action:  action.Replace,
-		Object: keystoreInterface.NameChangedEvent{
-			Name:            deviceName,
-			RootFingerprint: slices.Clone(rootFingerprint),
-		},
-	})
+
+	if ks := device.Keystore(); ks != nil {
+		if bb02Keysytore, ok := ks.(*keystore); ok {
+			rootFingerprint, err := bb02Keysytore.RootFingerprint()
+			if err != nil {
+				// Best effort, not critical.
+				return nil
+			}
+
+			bb02Keysytore.Notify(observable.Event{
+				Subject: string(keystoreInterface.EventNameChanged),
+				Action:  action.Replace,
+				Object: keystoreInterface.NameChangedEvent{
+					Name:            deviceName,
+					RootFingerprint: slices.Clone(rootFingerprint),
+				},
+			})
+		}
+	}
 	return nil
 }
 

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -14,6 +14,7 @@ import (
 	keystorePkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
@@ -26,11 +27,19 @@ import (
 )
 
 type keystore struct {
+	observable.Implementation
+
 	device *Device
 	log    *logrus.Entry
 
 	rootFingerMu sync.Mutex
 	rootFinger   []byte // cached result of RootFingerprint
+}
+
+func (keystore *keystore) clearRootFingerprintCache() {
+	keystore.rootFingerMu.Lock()
+	defer keystore.rootFingerMu.Unlock()
+	keystore.rootFinger = nil
 }
 
 // Type implements keystore.Keystore.

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -8,6 +8,7 @@ import (
 	btctypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -42,10 +43,20 @@ var (
 // ErrSigningAborted is used when the user aborts a signing in process (e.g. abort on HW wallet).
 var ErrSigningAborted = errors.New("signing aborted by user")
 
+// Event instances are emitted by keystore implementations.
+type Event string
+
+const (
+	// EventNameChanged is emitted when the keystore name changes.
+	EventNameChanged Event = "nameChanged"
+)
+
 // Keystore supports hardened key derivation according to BIP32 and signing of transactions.
 //
 //go:generate moq -pkg mocks -out mocks/keystore.go . Keystore
 type Keystore interface {
+	observable.Interface
+
 	// Type denotes the type of the keystore.
 	Type() Type
 

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -51,6 +51,12 @@ const (
 	EventNameChanged Event = "nameChanged"
 )
 
+// NameChangedEvent is the payload for EventNameChanged.
+type NameChangedEvent struct {
+	Name            string
+	RootFingerprint []byte
+}
+
 // Keystore supports hardened key derivation according to BIP32 and signing of transactions.
 //
 //go:generate moq -pkg mocks -out mocks/keystore.go . Keystore

--- a/backend/keystore/mocks/keystore.go
+++ b/backend/keystore/mocks/keystore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/ethereum/go-ethereum/core/types"
 	"sync"
@@ -43,6 +44,9 @@ var _ keystore.Keystore = &KeystoreMock{}
 //			},
 //			NameFunc: func() (string, error) {
 //				panic("mock out the Name method")
+//			},
+//			ObserveFunc: func(fn func(observable.Event)) func() {
+//				panic("mock out the Observe method")
 //			},
 //			RootFingerprintFunc: func() ([]byte, error) {
 //				panic("mock out the RootFingerprint method")
@@ -116,6 +120,9 @@ type KeystoreMock struct {
 
 	// NameFunc mocks the Name method.
 	NameFunc func() (string, error)
+
+	// ObserveFunc mocks the Observe method.
+	ObserveFunc func(fn func(observable.Event)) func()
 
 	// RootFingerprintFunc mocks the RootFingerprint method.
 	RootFingerprintFunc func() ([]byte, error)
@@ -196,6 +203,11 @@ type KeystoreMock struct {
 		}
 		// Name holds details about calls to the Name method.
 		Name []struct {
+		}
+		// Observe holds details about calls to the Observe method.
+		Observe []struct {
+			// Fn is the fn argument value.
+			Fn func(observable.Event)
 		}
 		// RootFingerprint holds details about calls to the RootFingerprint method.
 		RootFingerprint []struct {
@@ -296,6 +308,7 @@ type KeystoreMock struct {
 	lockExtendedPublicKey               sync.RWMutex
 	lockFeatures                        sync.RWMutex
 	lockName                            sync.RWMutex
+	lockObserve                         sync.RWMutex
 	lockRootFingerprint                 sync.RWMutex
 	lockSignBTCMessage                  sync.RWMutex
 	lockSignETHMessage                  sync.RWMutex
@@ -527,6 +540,38 @@ func (mock *KeystoreMock) NameCalls() []struct {
 	mock.lockName.RLock()
 	calls = mock.calls.Name
 	mock.lockName.RUnlock()
+	return calls
+}
+
+// Observe calls ObserveFunc.
+func (mock *KeystoreMock) Observe(fn func(observable.Event)) func() {
+	if mock.ObserveFunc == nil {
+		panic("KeystoreMock.ObserveFunc: method is nil but Keystore.Observe was just called")
+	}
+	callInfo := struct {
+		Fn func(observable.Event)
+	}{
+		Fn: fn,
+	}
+	mock.lockObserve.Lock()
+	mock.calls.Observe = append(mock.calls.Observe, callInfo)
+	mock.lockObserve.Unlock()
+	return mock.ObserveFunc(fn)
+}
+
+// ObserveCalls gets all the calls that were made to Observe.
+// Check the length with:
+//
+//	len(mockedKeystore.ObserveCalls())
+func (mock *KeystoreMock) ObserveCalls() []struct {
+	Fn func(observable.Event)
+} {
+	var calls []struct {
+		Fn func(observable.Event)
+	}
+	mock.lockObserve.RLock()
+	calls = mock.calls.Observe
+	mock.lockObserve.RUnlock()
 	return calls
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -16,6 +16,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
@@ -29,6 +30,8 @@ import (
 
 // Keystore implements a keystore in software.
 type Keystore struct {
+	observable.Implementation
+
 	// The master extended private key from which all keys are derived.
 	master     *hdkeychain.ExtendedKey
 	identifier string

--- a/util/observable/implementation.go
+++ b/util/observable/implementation.go
@@ -2,7 +2,12 @@
 
 package observable
 
-import "github.com/BitBoxSwiss/bitbox-wallet-app/util/locker"
+import (
+	"maps"
+	"slices"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/locker"
+)
 
 // Implementation can be embedded in implementations that are observable.
 type Implementation struct {
@@ -30,8 +35,11 @@ func (implementation *Implementation) Observe(observer func(Event)) func() {
 // Notify notifies the registered observers about the given event.
 // This method should only be called from the implementation itself.
 func (implementation *Implementation) Notify(event Event) {
-	defer implementation.observersLock.RLock()()
-	for _, observer := range implementation.observers {
+	unlock := implementation.observersLock.RLock()
+	observers := slices.Collect(maps.Values(implementation.observers))
+	unlock()
+
+	for _, observer := range observers {
 		observer(event)
 	}
 }


### PR DESCRIPTION
- Sorts the accounts again, as they are first sorted by keystore name
- Updates sidebar and other accounts views with updated keystore name
